### PR TITLE
Fix Snap application icon metadata

### DIFF
--- a/art.taunoerik.tauno-serial-plotter.desktop
+++ b/art.taunoerik.tauno-serial-plotter.desktop
@@ -5,6 +5,6 @@ Name=Tauno Serial Plotter
 Comment=Simple serial plotter
 TryExec=tauno-serial-plotter
 Exec=tauno-serial-plotter.py
-Icon=art.taunoerik.tauno-serial-plotter.svg
+Icon=art.taunoerik.tauno-serial-plotter
 Categories=Utility;
 Keywords=Serial

--- a/data/art.taunoerik.tauno-serial-plotter.desktop
+++ b/data/art.taunoerik.tauno-serial-plotter.desktop
@@ -4,6 +4,6 @@ Type=Application
 Name=Tauno Serial Plotter
 Comment=Simple serial plotter
 Exec=tauno-serial-plotter
-Icon=art.taunoerik.tauno-serial-plotter.svg
+Icon=art.taunoerik.tauno-serial-plotter
 Categories=Utility;
 Keywords=Serial

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ description: |
   sudo snap connect tauno-serial-plotter:serial-port
 compression: lzo
 license: GPL-3.0
+icon: src/icons/art.taunoerik.tauno-serial-plotter.svg
 contact: sedumacre@gmail.com
 website: https://github.com/taunoe/tauno-serial-plotter
 issues: https://github.com/taunoe/tauno-serial-plotter/issues


### PR DESCRIPTION
Snap installations can show the application without an icon because the desktop entries use the SVG filename instead of the icon theme name, and the Snap manifest does not declare a store icon.

This updates both desktop entries to use the extensionless icon name and declares the SVG as the Snap icon so desktop integration and Snap Store metadata resolve consistently.