### PR TITLE
Extract theme handling and release version 1.21.2

### DIFF
--- a/art.taunoerik.tauno-serial-plotter.appdata.xml
+++ b/art.taunoerik.tauno-serial-plotter.appdata.xml
@@ -56,6 +56,13 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.21.2" date="2026-09-11">
+     <description>
+       <ul>
+         <li>Theme module refactoring.</li>
+       </ul>
+     </description>
+    </release>
     <release version="1.20.8" date="2026-09-08">
      <description>
        <ul>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="tauno-serial-plotter",
-    version="1.21.1",
+    version="1.21.2",
     author="Tauno Erik",
     author_email="sedumacre@gmail.com",
     description="Tauno-Serial-Plotter is simple serial plotter.",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ title: Tauno Serial Plotter
 base: core24
 grade: stable
 confinement: strict
-version: '1.21.1'
+version: '1.21.2'
 summary: Simple serial plotter
 description: |
   Tauno Serial Plotter is simple serial plotter for Arduino and others.

--- a/src/tauno-serial-plotter.py
+++ b/src/tauno-serial-plotter.py
@@ -7,9 +7,7 @@
 """
 import sys
 import re
-import os
 import logging
-import subprocess
 from enum import Enum, auto
 import serial
 import serial.tools.list_ports
@@ -19,9 +17,9 @@ from PyQt6.QtCore import (QSettings, Qt, QMetaObject, QThread, pyqtSignal,
 from PyQt6.QtWidgets import (QApplication, QHBoxLayout, QVBoxLayout,
                             QLabel, QWidget, QMessageBox)
 import pyqtgraph as pg
-import platform
+from theme import create_theme
 
-VERSION = '1.21.1'
+VERSION = '1.21.2'
 TIMESCALESIZE = 400  # = self.plot_timescale and self.plot_data_size
 
 if __name__ == '__main__':
@@ -32,6 +30,16 @@ if __name__ == '__main__':
     if hasattr(Qt, 'AA_Use96Dpi'):
         QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_Use96Dpi, True)
     app = QApplication(sys.argv)
+    theme = create_theme(app)
+    colors = theme.colors
+    plot_colors = theme.plot_colors
+    icon_logo = theme.icons["logo"]
+    icon_minus = theme.icons["minus"]
+    icon_plus = theme.icons["plus"]
+    icon_arrow_down = theme.icons["arrow_down"]
+    icon_about = theme.icons["about"]
+    icon_clean = theme.icons["clean"]
+    icon_size = theme.icons["size"]
 
 
 class ConnectionState(Enum):
@@ -45,105 +53,6 @@ class ConnectionState(Enum):
 logging.basicConfig(level=logging.DEBUG)
 #logging.basicConfig(level=logging.CRITICAL)
 
-
-# GUI Icons
-if platform.system() == 'Windows' :
-    icon_logo = "./icons/tauno-serial-plotter.svg"
-    icon_minus = "./icons/minus.svg"
-    icon_plus = "./icons/plus.svg"
-    icon_arrow_down = "./icons/arrow_down.svg"
-    icon_about = "./icons/help-about-symbolic.svg"
-    icon_clean = "./icons/larger-brush-symbolic.svg"
-    icon_size = "./icons/ruler-end-horizontal-left-symbolic.svg"
-else:
-    icon_logo = os.path.join(os.path.dirname(__file__), 'icons/tauno-serial-plotter.svg')
-    icon_minus = os.path.join(os.path.dirname(__file__), 'icons/minus.svg')
-    icon_plus = os.path.join(os.path.dirname(__file__), 'icons/plus.svg')
-    icon_arrow_down = os.path.join(os.path.dirname(__file__), 'icons/arrow_down.svg')
-    icon_about = os.path.join(os.path.dirname(__file__), 'icons/help-about-symbolic.svg')
-    icon_clean = os.path.join(os.path.dirname(__file__), 'icons/larger-brush-symbolic.svg')
-    icon_size = os.path.join(os.path.dirname(__file__), 'icons/ruler-end-horizontal-left-symbolic.svg')
-
-def system_theme():
-    """Return the platform color scheme, or a platform-neutral light fallback."""
-    app = QtWidgets.QApplication.instance()
-    if app is not None:
-        scheme = app.styleHints().colorScheme()
-        if scheme == QtCore.Qt.ColorScheme.Dark:
-            return "dark"
-        if scheme == QtCore.Qt.ColorScheme.Light:
-            return "light"
-    return "light"
-
-
-def system_accent_color(dark):
-    """Return the GNOME accent color as a stylesheet-compatible hex value."""
-    accent_colors = {
-        "blue": ("#62A0EA", "#3584E4"),
-        "teal": ("#5BC8AF", "#2190A4"),
-        "green": ("#57E389", "#33D17A"),
-        "yellow": ("#F8E45C", "#F6D32D"),
-        "orange": ("#FFBE6F", "#FF7800"),
-        "red": ("#FF7B63", "#E01B24"),
-        "pink": ("#DC8ADD", "#C061CB"),
-        "purple": ("#C061CB", "#9141AC"),
-        "slate": ("#949390", "#5E5C64"),
-    }
-    try:
-        result = subprocess.run(
-            ["gsettings", "get", "org.gnome.desktop.interface", "accent-color"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=1,
-        )
-        accent = result.stdout.strip().strip("'")
-        if accent in accent_colors:
-            return accent_colors[accent][0 if dark else 1]
-    except (OSError, subprocess.SubprocessError):
-        logging.debug("GNOME accent color is unavailable", exc_info=True)
-    return "#9CCC65" if dark else "#62A0EA"
-
-
-# GUI colours, matching GNOME's dark and light Adwaita palettes.
-dark_theme = system_theme() == "dark"
-if dark_theme:
-    colors = {
-        'oranz': "#FF6F00",
-        'accent': system_accent_color(True),
-        'dark': "#1d1d20",
-        'hall': "#B0BEC5",
-        'black': "#212121",
-        'foreground': "#B0BEC5",
-    }
-else:
-    colors = {
-        'oranz': "#C64600",
-        'accent': system_accent_color(False),
-        'dark': "#F6F5F4",
-        'hall': "#FFFFFF",
-        'black': "#2E3436",
-        'foreground': "#2E3436",
-    }
-
-# PLOT colors
-plot_colors = [
-    "#ba8310", # Kollane
-    "#00BCD4", # syan
-    "#3F51B5", # indigo
-    "#E91E63", # pink
-    "#FF9800", # orange
-    "#9C27B0", # purple
-    "#4CAF50", # green
-    "#FFC107", # amber
-    "#f44336", # red
-    "#03A9F4", # light blue
-    "#FFEB3B", # yellow
-    "#CDDC39", # lime
-    "#2196F3", # blue
-    "#8BC34A", # light green
-    "#009688"  # teal
-    ]
 
 # STYLING
 FONTSIZE = '16px'

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,0 +1,103 @@
+"""Application theme, platform colors, and bundled icon paths."""
+
+import logging
+import os
+import platform
+import subprocess
+from dataclasses import dataclass
+
+from PyQt6 import QtCore, QtWidgets
+
+
+PLOT_COLORS = [
+    "#ba8310", "#00BCD4", "#3F51B5", "#E91E63", "#FF9800",
+    "#9C27B0", "#4CAF50", "#FFC107", "#f44336", "#03A9F4",
+    "#FFEB3B", "#CDDC39", "#2196F3", "#8BC34A", "#009688",
+]
+
+
+def _system_theme(app):
+    """Return the platform color scheme, defaulting to light."""
+    scheme = app.styleHints().colorScheme()
+    if scheme == QtCore.Qt.ColorScheme.Dark:
+        return "dark"
+    return "light"
+
+
+def _system_accent_color(dark):
+    """Return the GNOME accent color, with a portable fallback."""
+    accent_colors = {
+        "blue": ("#62A0EA", "#3584E4"),
+        "teal": ("#5BC8AF", "#2190A4"),
+        "green": ("#57E389", "#33D17A"),
+        "yellow": ("#F8E45C", "#F6D32D"),
+        "orange": ("#FFBE6F", "#FF7800"),
+        "red": ("#FF7B63", "#E01B24"),
+        "pink": ("#DC8ADD", "#C061CB"),
+        "purple": ("#C061CB", "#9141AC"),
+        "slate": ("#949390", "#5E5C64"),
+    }
+    try:
+        result = subprocess.run(
+            ["gsettings", "get", "org.gnome.desktop.interface", "accent-color"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+        accent = result.stdout.strip().strip("'")
+        if accent in accent_colors:
+            return accent_colors[accent][0 if dark else 1]
+    except (OSError, subprocess.SubprocessError):
+        logging.debug("GNOME accent color is unavailable", exc_info=True)
+    return "#9CCC65" if dark else "#62A0EA"
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Resolved colors and resource paths for one application session."""
+
+    dark: bool
+    colors: dict
+    icons: dict
+    plot_colors: list
+
+
+def create_theme(app):
+    """Resolve the theme after QApplication has loaded platform settings."""
+    dark = _system_theme(app) == "dark"
+    if dark:
+        colors = {
+            "oranz": "#FF6F00",
+            "accent": _system_accent_color(True),
+            "dark": "#1d1d20",
+            "hall": "#B0BEC5",
+            "black": "#212121",
+            "foreground": "#B0BEC5",
+        }
+    else:
+        colors = {
+            "oranz": "#C64600",
+            "accent": _system_accent_color(False),
+            "dark": "#F6F5F4",
+            "hall": "#FFFFFF",
+            "black": "#2E3436",
+            "foreground": "#2E3436",
+        }
+
+    if platform.system() == "Windows":
+        icon_dir = os.path.join(".", "icons")
+    else:
+        icon_dir = os.path.join(os.path.dirname(__file__), "icons")
+    icon_names = {
+        "logo": "tauno-serial-plotter.svg",
+        "minus": "minus.svg",
+        "plus": "plus.svg",
+        "arrow_down": "arrow_down.svg",
+        "about": "help-about-symbolic.svg",
+        "clean": "larger-brush-symbolic.svg",
+        "size": "ruler-end-horizontal-left-symbolic.svg",
+    }
+    icons = {name: os.path.join(icon_dir, filename)
+             for name, filename in icon_names.items()}
+    return Theme(dark, colors, icons, PLOT_COLORS)


### PR DESCRIPTION
The theme and platform-integration logic had grown inside the main 1,100-line application module, making it harder to maintain and causing theme initialization to depend on application startup details. This change isolates that responsibility while preserving the Flatpak-compatible Qt color-scheme detection.

### Changes
- Add `src/theme.py` with theme resolution, GNOME accent-color handling, color palettes, plot colors, and icon paths.
- Resolve the theme after `QApplication` is created and pass the resulting values to the existing UI styling.
- Update runtime, setup, Snap, and AppStream metadata to version 1.21.2.

### Validation
- Python compilation for both application modules.
- AppStream XML parsing.
- `git diff --check`.
- Existing offscreen startup and theme construction smoke checks passed before commit.