### PR TITLE
Fix Snap and Flatpak packaging for extracted theme module

### DIFF
--- a/doc/Build-flatpak.md
+++ b/doc/Build-flatpak.md
@@ -4,6 +4,18 @@ Official Flatpak repository is [github.com/flathub/art.taunoerik.tauno-serial-pl
 
 The Flatpak app [maintenance guide](https://github.com/flathub/flathub/wiki/App-Maintenance).
 
+The manifest must install both Python modules next to the launcher:
+
+```yaml
+build-commands:
+  - install -D src/tauno-serial-plotter.py /app/bin/tauno-serial-plotter.py
+  - install -D src/theme.py /app/bin/theme.py
+```
+
+`tauno-serial-plotter.py` imports `theme` at runtime. If the Flatpak
+manifest installs only the launcher, the application will fail with
+`ModuleNotFoundError: No module named 'theme'`.
+
 ## Some commands
 
 Build localy:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,7 +78,8 @@ parts:
       craftctl default
       # Ensure the script is in the bin folder and executable
       mkdir -p $CRAFT_PART_INSTALL/bin
-      cp -av src/tauno-serial-plotter.py $CRAFT_PART_INSTALL/bin/
+      cp -av src/tauno-serial-plotter.py src/theme.py \
+            $CRAFT_PART_INSTALL/bin/
       chmod +x $CRAFT_PART_INSTALL/bin/tauno-serial-plotter.py
 
       # 2. Install the Icon to the standard system path


### PR DESCRIPTION
The theme refactor added a runtime `theme` module import, but the Snap build copied only the main launcher. The Flatpak manifest uses the same packaging pattern, so either package could install an incomplete application and fail with `ModuleNotFoundError`.

This change:
- Copies `src/theme.py` beside the launcher in the Snap image.
- Documents the required Flatpak manifest commands to install both Python modules.

The Flathub manifest is maintained in the separate `flathub/art.taunoerik.tauno-serial-plotter` repository and must apply the documented install command there.