### PR TITLE
Hide metadata-free legacy serial ports

### DIFF
--- a/src/tauno-serial-plotter.py
+++ b/src/tauno-serial-plotter.py
@@ -49,6 +49,27 @@ class ConnectionState(Enum):
     CONNECTED = auto()
     ERROR = auto()
 
+
+def include_serial_port(port):
+    """Hide metadata-free legacy UARTs while retaining real hardware ports."""
+    device = getattr(port, "device", "")
+    if not device.startswith("/dev/ttyS"):
+        return True
+
+    metadata_fields = (
+        "manufacturer",
+        "serial_number",
+        "product",
+        "interface",
+        "location",
+    )
+    if any(getattr(port, field, None) for field in metadata_fields):
+        return True
+    if getattr(port, "vid", None) is not None or getattr(port, "pid", None) is not None:
+        return True
+    return "USB" in (getattr(port, "hwid", "") or "").upper()
+
+
 # Set debuge level
 logging.basicConfig(level=logging.DEBUG)
 #logging.basicConfig(level=logging.CRITICAL)
@@ -301,7 +322,11 @@ class PortScanner(QtCore.QObject):
         """Scan ports without touching any GUI objects."""
         ports = []
         try:
-            ports = [port.device for port in serial.tools.list_ports.comports()]
+            ports = [
+                port.device
+                for port in serial.tools.list_ports.comports()
+                if include_serial_port(port)
+            ]
         except OSError:
             logging.exception("Unable to scan serial ports")
         self.ports_found.emit(ports)


### PR DESCRIPTION
The port selector currently shows every device returned by pyserial, including unused legacy `/dev/ttyS*` entries. These ports are usually not useful for USB serial workflows and make it harder to find connected hardware.

This change filters only metadata-free `/dev/ttyS*` devices. A legacy UART remains visible when pyserial reports manufacturer, serial number, product/interface/location data, VID/PID, or USB information in its hardware ID. USB and other non-`ttyS` devices remain unchanged.

Focused filtering checks and Python syntax validation passed.