### PR TITLE
Extract serial data parser into a module

### DIFF
--- a/doc/Build-flatpak.md
+++ b/doc/Build-flatpak.md
@@ -4,17 +4,18 @@ Official Flatpak repository is [github.com/flathub/art.taunoerik.tauno-serial-pl
 
 The Flatpak app [maintenance guide](https://github.com/flathub/flathub/wiki/App-Maintenance).
 
-The manifest must install both Python modules next to the launcher:
+The manifest must install all Python modules next to the launcher:
 
 ```yaml
 build-commands:
   - install -D src/tauno-serial-plotter.py /app/bin/tauno-serial-plotter.py
+  - install -D src/parser.py /app/bin/parser.py
   - install -D src/theme.py /app/bin/theme.py
 ```
 
-`tauno-serial-plotter.py` imports `theme` at runtime. If the Flatpak
-manifest installs only the launcher, the application will fail with
-`ModuleNotFoundError: No module named 'theme'`.
+`tauno-serial-plotter.py` imports `parser` and `theme` at runtime. If the
+Flatpak manifest installs only the launcher, the application will fail with
+`ModuleNotFoundError`.
 
 ## Some commands
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -78,7 +78,7 @@ parts:
       craftctl default
       # Ensure the script is in the bin folder and executable
       mkdir -p $CRAFT_PART_INSTALL/bin
-      cp -av src/tauno-serial-plotter.py src/theme.py \
+      cp -av src/tauno-serial-plotter.py src/parser.py src/theme.py \
             $CRAFT_PART_INSTALL/bin/
       chmod +x $CRAFT_PART_INSTALL/bin/tauno-serial-plotter.py
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,0 +1,17 @@
+"""Parsing helpers for serial plotter input."""
+
+import re
+
+
+NUMBER_PATTERN = re.compile(r"[-+]?[0-9]*\.?[0-9]+")
+LABEL_PATTERN = re.compile(r"[-+]?[a-zA-Z]*\.?[a-zA-Z]+")
+
+
+def parse_numbers(text):
+    """Return numeric fields found in a serial data line."""
+    return NUMBER_PATTERN.findall(text)
+
+
+def parse_labels(text):
+    """Return alphabetic labels found in a serial data line."""
+    return LABEL_PATTERN.findall(text)

--- a/src/tauno-serial-plotter.py
+++ b/src/tauno-serial-plotter.py
@@ -6,7 +6,6 @@
     Edited:  08.09.2026
 """
 import sys
-import re
 import logging
 from enum import Enum, auto
 import serial
@@ -17,6 +16,7 @@ from PyQt6.QtCore import (QSettings, Qt, QMetaObject, QThread, pyqtSignal,
 from PyQt6.QtWidgets import (QApplication, QHBoxLayout, QVBoxLayout,
                             QLabel, QWidget, QMessageBox)
 import pyqtgraph as pg
+from parser import parse_labels, parse_numbers
 from theme import create_theme
 
 VERSION = '1.21.2'
@@ -397,10 +397,10 @@ class SerialWorker(QtCore.QObject):
                 return
 
             if self.probing:
-                numbers = re.findall(r'[-+]?[0-9]*\.?[0-9]+', line)
+                numbers = parse_numbers(line)
                 if not numbers:
                     return
-                labels = re.findall(r'[-+]?[a-zA-Z]*\.?[a-zA-Z]+', line)
+                labels = parse_labels(line)
                 self.probing = False
                 self.connected.emit(len(numbers), labels)
             self.data_received.emit(line)
@@ -915,7 +915,7 @@ class MainWindow(QWidget):
                 or self.connection_state != ConnectionState.CONNECTED):
             return
         try:
-            numbers = self.get_numbers(incoming_data)
+            numbers = parse_numbers(incoming_data)
 
             for count, value in enumerate(numbers[:self.number_of_lines]):
                 self.add_numbers(count, value, self.plot_data_size)
@@ -954,21 +954,6 @@ class MainWindow(QWidget):
             Tauno Erik<br/><br/>\
             2021-2026".format(VERSION))
         self.aboutbox.exec()
-
-    def get_numbers(self, string):
-        """
-        Function to extract all the numbers from the given string
-        https://www.regular-expressions.info/floatingpoint.html
-        """
-        numbers = re.findall(r'[-+]?[0-9]*\.?[0-9]+', string)
-        return numbers
-    
-    def get_labels(self, string):
-        """
-        Function to extract all the labels from the given string
-        """
-        labels = re.findall(r'[-+]?[a-zA-Z]*\.?[a-zA-Z]+', string)
-        return labels
 
     def add_numbers(self, i, number, plot_data_size):
         """


### PR DESCRIPTION
Serial parsing was duplicated between connection probing and live plot updates inside the main GUI module. That made protocol behavior harder to test and required packaging every new helper manually without a clear boundary.

This change adds a pure `src/parser.py` module with shared numeric and label parsing functions, updates both serial code paths to use it, and removes the duplicated methods and regex logic from the main module. Snap packaging and Flatpak build documentation now include the parser module alongside the launcher and theme module.

Validation completed with Python compilation, focused parser checks, offscreen startup smoke testing, and `git diff --check`.