### PR TITLE
Bump version to 1.21.3

### DIFF
--- a/art.taunoerik.tauno-serial-plotter.appdata.xml
+++ b/art.taunoerik.tauno-serial-plotter.appdata.xml
@@ -56,6 +56,11 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="1.21.3" date="2026-09-12">
+      <description>
+        <p>Improved serial port control styling and widget presentation structure.</p>
+      </description>
+    </release>
     <release version="1.21.2" date="2026-09-11">
      <description>
        <ul>

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="tauno-serial-plotter",
-    version="1.21.2",
+    version="1.21.3",
     author="Tauno Erik",
     author_email="sedumacre@gmail.com",
     description="Tauno-Serial-Plotter is simple serial plotter.",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ title: Tauno Serial Plotter
 base: core24
 grade: stable
 confinement: strict
-version: '1.21.2'
+version: '1.21.3'
 summary: Simple serial plotter
 description: |
   Tauno Serial Plotter is simple serial plotter for Arduino and others.

--- a/src/tauno-serial-plotter.py
+++ b/src/tauno-serial-plotter.py
@@ -17,7 +17,7 @@ from serial_workers import PortScanner, SerialWorker
 from theme import create_theme
 from widgets import Controls, Plot, create_styles
 
-VERSION = '1.21.2'
+VERSION = '1.21.3'
 TIMESCALESIZE = 400  # = self.plot_timescale and self.plot_data_size
 
 class ConnectionState(Enum):


### PR DESCRIPTION
## Why

Publish the next application release with consistent version metadata across runtime, package, Snap, and AppStream configuration.

## What changed

- Bumped the application version to `1.21.3` in the launcher, `setup.py`, and Snap metadata.
- Added the `1.21.3` AppStream release entry dated 2026-09-12.

## Validation

- Python compilation passed.
- AppStream XML parsing passed.
- `git diff --check` passed.